### PR TITLE
feat(movie): 영화 디테일 페이지 구현(/movie/:id) — 라우팅 + 데이터 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
 .env

--- a/src/app/shell/AppShell.jsx
+++ b/src/app/shell/AppShell.jsx
@@ -5,7 +5,8 @@ export default function AppShell() {
   return (
     <div className="min-h-screen bg-neutral-950 text-white">
       <NavigationBar />
-      <main className="mx-auto max-w-6xl px-4 py-6">
+      {/* 전역 타이포 리듬 */}
+      <main className="leading-relaxed">
         <Outlet />
       </main>
     </div>

--- a/src/components/common/Container.jsx
+++ b/src/components/common/Container.jsx
@@ -1,5 +1,8 @@
 export default function Container({ className = "", children }) {
+  // 넓은 화면에서도 콘텐츠 폭을 5xl로 제한, 패딩은 반응형으로
   return (
-    <div className={`mx-auto max-w-6xl px-4 ${className}`}>{children}</div>
+    <div className={`mx-auto max-w-5xl px-4 sm:px-6 md:px-8 ${className}`}>
+      {children}
+    </div>
   );
 }

--- a/src/components/common/Section.jsx
+++ b/src/components/common/Section.jsx
@@ -1,8 +1,10 @@
 export default function Section({ title, children, right }) {
   return (
-    <section className="py-6">
-      <div className="mb-4 flex items-end justify-between gap-3">
-        <h2 className="text-xl font-semibold">{title}</h2>
+    <section className="py-6 md:py-8">
+      <div className="mb-3 flex items-end justify-between gap-3 md:mb-4">
+        <h2 className="text-lg font-semibold tracking-tight md:text-2xl">
+          {title}
+        </h2>
         {right}
       </div>
       {children}

--- a/src/features/movie/api/getMovieById.js
+++ b/src/features/movie/api/getMovieById.js
@@ -1,0 +1,11 @@
+import { buildUrl } from "@/constants/api.js";
+
+export async function getMovieById(id, { signal } = {}) {
+  const url = buildUrl(`/movie/${id}`, { language: "ko-KR" });
+  const res = await fetch(url, {
+    signal,
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) throw new Error(`TMDB ${res.status} ${res.statusText}`);
+  return res.json();
+}

--- a/src/features/movie/hooks/useMovieDetail.js
+++ b/src/features/movie/hooks/useMovieDetail.js
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+import { getMovieById } from "../api/getMovieById.js";
+
+export function useMovieDetail(id) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    const ctrl = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    getMovieById(id, { signal: ctrl.signal })
+      .then(setData)
+      .catch((e) => !ctrl.signal.aborted && setError(e))
+      .finally(() => !ctrl.signal.aborted && setLoading(false));
+
+    return () => ctrl.abort();
+  }, [id]);
+
+  return { data, loading, error };
+}

--- a/src/pages/MovieDetailPage.jsx
+++ b/src/pages/MovieDetailPage.jsx
@@ -1,10 +1,92 @@
+import Button from "@/components/common/Button.jsx";
 import Container from "@/components/common/Container.jsx";
+import Skeleton from "@/components/common/Skeleton.jsx";
+import { useMovieDetail } from "@/features/movie/hooks/useMovieDetail.js";
+import { Link, useParams } from "react-router-dom";
+
+function minToHM(min = 0) {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return h ? `${h}시간 ${m}분` : `${m}분`;
+}
+
 export default function MovieDetailPage() {
+  const { id } = useParams();
+  const { data: m, loading, error } = useMovieDetail(Number(id));
+
+  if (loading) {
+    return (
+      <Container className="py-8">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-[200px,1fr]">
+          <Skeleton className="aspect-2/3 w-full" />
+          <div className="space-y-3">
+            <Skeleton className="h-7 w-2/3" />
+            <Skeleton className="h-4 w-1/3" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+          </div>
+        </div>
+      </Container>
+    );
+  }
+
+  if (error || !m) {
+    return (
+      <Container className="py-8">
+        <div className="rounded-lg border border-red-700 bg-red-900/20 p-4 text-sm text-red-300">
+          상세 정보를 불러오는 중 오류가 발생했습니다.
+          <div className="mt-3 flex gap-2">
+            <Button onClick={() => location.reload()}>새로고침</Button>
+            <Link to="/">
+              <Button as="a">홈으로</Button>
+            </Link>
+          </div>
+        </div>
+      </Container>
+    );
+  }
+
+  const poster = m.poster_path
+    ? `https://image.tmdb.org/t/p/w500${m.poster_path}`
+    : "https://placehold.co/500x750?text=No+Image";
+  const genres = (m.genres || []).map((g) => g.name).join(" · ");
+
   return (
-    <Container>
-      <div className="py-8">
-        <h1 className="text-2xl font-semibold">Movie Detail</h1>
-        <p className="mt-2 text-neutral-300">추후 API 연동 예정</p>
+    <Container className="py-8">
+      <Link to="/" className="text-sm text-neutral-400 hover:text-white">
+        ← 홈으로
+      </Link>
+
+      <div className="mt-4 grid grid-cols-1 gap-6 md:grid-cols-[220px,1fr]">
+        <img
+          src={poster}
+          alt={m.title}
+          className="aspect-2/3 w-full rounded-lg object-cover"
+        />
+        <div className="space-y-3">
+          <h1 className="text-2xl font-semibold">{m.title}</h1>
+          <p className="text-neutral-300">
+            {m.overview || "줄거리 정보가 없습니다."}
+          </p>
+
+          <ul className="mt-2 text-sm text-neutral-300">
+            <li>
+              <span className="text-neutral-400">평점</span> · ⭐{" "}
+              {m.vote_average?.toFixed?.(1) ?? "-"}
+            </li>
+            <li>
+              <span className="text-neutral-400">개봉</span> ·{" "}
+              {m.release_date || "-"}
+            </li>
+            <li>
+              <span className="text-neutral-400">상영시간</span> ·{" "}
+              {m.runtime ? minToHM(m.runtime) : "-"}
+            </li>
+            <li>
+              <span className="text-neutral-400">장르</span> · {genres || "-"}
+            </li>
+          </ul>
+        </div>
       </div>
     </Container>
   );


### PR DESCRIPTION
### PR 타입
- [x] feat

### 반영 브랜치
feat/13--build-movie-detail → dev

### 관련 이슈
Closes #13

### 개요
> 카드 클릭 시 /movie/:id 상세 페이지로 이동. v3 api_key로 상세 데이터 렌더.
히어로(백드롭), 포스터 상한/스티키, 메타칩, 로딩/에러/빈 상태 포함.

### 변경 사항
- router: /movie/:id 라우트 활성화
- api: getMovieById(id)
- hooks: useMovieDetail(id) (AbortController)
- ui: MovieDetailPage 레이아웃/상태 UI
- nav: MovieCard → /movie/:id 링크

### 테스트 결과
- [x] /movie/550 등 상세 진입 200 OK
- [x] 로딩/에러/빈 상태 동작
- [x] format/lint 통과, 콘솔 에러 0
