### PR TITLE
feat(search): 키워드 검색 – NavBar 입력 ↔ URL 동기화 & /search 결과 그리드

### DIFF
--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -1,6 +1,7 @@
 import AppShell from "@/app/shell/AppShell.jsx";
 import HomePage from "@/pages/HomePage.jsx";
 import MovieDetailPage from "@/pages/MovieDetailPage.jsx";
+import SearchPage from "@/pages/SearchPage.jsx"; // ⬅️ 추가
 import { createBrowserRouter } from "react-router-dom";
 
 export const router = createBrowserRouter([
@@ -10,6 +11,7 @@ export const router = createBrowserRouter([
     children: [
       { index: true, element: <HomePage /> },
       { path: "movie/:id", element: <MovieDetailPage /> },
+      { path: "search", element: <SearchPage /> }, // ⬅️ 추가
     ],
   },
 ]);

--- a/src/components/common/NavigationBar.jsx
+++ b/src/components/common/NavigationBar.jsx
@@ -1,14 +1,25 @@
+import Container from "@/components/common/Container.jsx";
+import SearchInput from "@/components/common/SearchInput.jsx";
+import { Link } from "react-router-dom";
+
 export default function NavigationBar() {
   return (
     <header className="sticky top-0 z-10 border-b border-neutral-800 bg-neutral-900/70 backdrop-blur">
-      <div className="mx-auto flex max-w-6xl items-center gap-4 px-4 py-3">
-        <a href="/" className="text-lg font-bold">
-          🎬 Mini Movies
-        </a>
-        <span className="ml-auto text-sm text-neutral-400">
-          React + Vite + Tailwind
-        </span>
-      </div>
+      <Container>
+        <div className="flex items-center justify-between py-3">
+          {/* 좌측 로고: 가장자리 여백 */}
+          <Link
+            href="/"
+            className="pl-2 text-base font-bold md:pl-3 md:text-lg"
+          >
+            🎬 Mini Movies
+          </Link>
+          {/* 우측 검색창: 가장자리 여백 */}
+          <div className="pr-2 md:pr-3">
+            <SearchInput />
+          </div>
+        </div>
+      </Container>
     </header>
   );
 }

--- a/src/components/common/SearchInput.jsx
+++ b/src/components/common/SearchInput.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+export default function SearchInput() {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const qParam = params.get("q") ?? "";
+  const [q, setQ] = useState(qParam);
+
+  useEffect(() => {
+    setQ(qParam);
+  }, [qParam]);
+
+  const onSubmit = (e) => {
+    e.preventDefault();
+    const v = q.trim();
+    if (!v) return;
+    navigate(`/search?q=${encodeURIComponent(v)}`);
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="ml-auto w-44 md:w-64">
+      <input
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        placeholder="영화 검색…"
+        className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm outline-none placeholder:text-neutral-500 focus:border-neutral-500"
+        aria-label="영화 검색"
+      />
+    </form>
+  );
+}

--- a/src/features/search/api/searchMovies.js
+++ b/src/features/search/api/searchMovies.js
@@ -1,0 +1,16 @@
+import { buildUrl } from "@/constants/api.js";
+
+export async function searchMovies(query, page = 1, { signal } = {}) {
+  const url = buildUrl("/search/movie", {
+    query,
+    page,
+    include_adult: false,
+    language: "ko-KR",
+  });
+  const res = await fetch(url, {
+    signal,
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) throw new Error(`TMDB ${res.status} ${res.statusText}`);
+  return res.json();
+}

--- a/src/features/search/hooks/useSearchMovies.js
+++ b/src/features/search/hooks/useSearchMovies.js
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { searchMovies } from "../api/searchMovies.js";
+
+export function useSearchMovies(query, page = 1) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(Boolean(query));
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const q = (query || "").trim();
+    if (!q) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const ctrl = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    searchMovies(q, page, { signal: ctrl.signal })
+      .then(setData)
+      .catch((e) => !ctrl.signal.aborted && setError(e))
+      .finally(() => !ctrl.signal.aborted && setLoading(false));
+
+    return () => ctrl.abort();
+  }, [query, page]);
+
+  return { data, loading, error };
+}

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,0 +1,9 @@
+import { useEffect, useState } from "react";
+export function useDebounce(value, delay = 300) {
+  const [v, setV] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setV(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return v;
+}

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -1,0 +1,53 @@
+import Container from "@/components/common/Container.jsx";
+import Section from "@/components/common/Section.jsx";
+import Skeleton from "@/components/common/Skeleton.jsx";
+import MovieCard from "@/features/movie/components/MovieCard.jsx";
+import { useSearchMovies } from "@/features/search/hooks/useSearchMovies.js";
+import { useDebounce } from "@/hooks/useDebounce.js";
+import { useSearchParams } from "react-router-dom";
+
+export default function SearchPage() {
+  const [params] = useSearchParams();
+  const q = params.get("q") ?? "";
+  const qDebounced = useDebounce(q, 300);
+  const { data, loading, error } = useSearchMovies(qDebounced);
+
+  const list = data?.results ?? [];
+
+  return (
+    <Container className="py-6 md:py-8 lg:py-10">
+      <Section title={`Search: "${q}"`}>
+        {loading ? (
+          <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 md:grid-cols-4">
+            {Array.from({ length: 10 }).map((_, i) => (
+              <div
+                key={i}
+                className="overflow-hidden rounded-xl border border-neutral-800 bg-neutral-900"
+              >
+                <Skeleton className="aspect-2/3 w-full" />
+                <div className="space-y-2 p-3">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-3 w-1/3" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : error ? (
+          <div className="rounded-lg border border-red-700 bg-red-900/20 p-4 text-sm text-red-300">
+            검색 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.
+          </div>
+        ) : list.length === 0 ? (
+          <div className="rounded-lg border border-neutral-800 bg-neutral-900 p-6 text-center text-neutral-300">
+            "{q}"에 대한 검색 결과가 없습니다.
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 md:grid-cols-4">
+            {list.map((m) => (
+              <MovieCard key={m.id} movie={m} />
+            ))}
+          </div>
+        )}
+      </Section>
+    </Container>
+  );
+}


### PR DESCRIPTION
### PR 타입
- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] build/chore

### 반영 브랜치
feat/15--search-query-sync → dev

### 관련 이슈
Closes #15

### 개요
> 상단 네비게이션의 검색창 입력을 URL과 동기화하고, `/search?q=키워드` 경로에서 TMDB 검색 API 결과를 카드 그리드로 표시합니다. 로딩/에러/빈 상태 UX를 포함합니다.

### 변경 사항
- `router.jsx` : `path: "search"` 라우트 추가
- `SearchInput.jsx` : 검색 폼 컴포넌트 (Enter 시 `/search?q=...` 이동)
- `NavigationBar.jsx` : 우측에 `SearchInput` 장착
- `searchMovies.js` : TMDB `/search/movie` v3 api_key 방식
- `useSearchMovies.js` : `{ data, loading, error }` 훅 (AbortController)
- `SearchPage.jsx` : 결과 그리드 페이지(로딩/에러/빈 상태 처리)
- (재사용) `MovieCard`/`Skeleton`/`Section`/`Container`