### PR TITLE
feat(theme): 다크/라이트 모드 토글 + 로컬 저장 + 전역 컬러 토큰 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,19 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <script>
+      (function () {
+        try {
+          const saved = localStorage.getItem("theme"); // 'dark' | 'light' | null
+          const prefersDark = window.matchMedia(
+            "(prefers-color-scheme: dark)",
+          ).matches;
+          const isDark = saved ? saved === "dark" : prefersDark;
+          document.documentElement.classList.toggle("dark", isDark);
+        } catch (_) {}
+      })();
+    </script>
+
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/app/shell/AppShell.jsx
+++ b/src/app/shell/AppShell.jsx
@@ -3,7 +3,7 @@ import { Outlet } from "react-router-dom";
 
 export default function AppShell() {
   return (
-    <div className="min-h-screen bg-neutral-950 text-white">
+    <div className="min-h-screen bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-50">
       <NavigationBar />
       {/* 전역 타이포 리듬 */}
       <main className="leading-relaxed">

--- a/src/components/common/NavigationBar.jsx
+++ b/src/components/common/NavigationBar.jsx
@@ -1,10 +1,11 @@
 import Container from "@/components/common/Container.jsx";
 import SearchInput from "@/components/common/SearchInput.jsx";
+import ThemeToggle from "@/components/common/ThemeToggle.jsx";
 import { Link } from "react-router-dom";
 
 export default function NavigationBar() {
   return (
-    <header className="sticky top-0 z-10 border-b border-neutral-800 bg-neutral-900/70 backdrop-blur">
+    <header className="sticky top-0 z-10 border-b border-neutral-200 bg-white/70 backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/70">
       <Container>
         <div className="flex items-center justify-between py-3">
           {/* 좌측 로고: 가장자리 여백 */}
@@ -12,11 +13,14 @@ export default function NavigationBar() {
             href="/"
             className="pl-2 text-base font-bold md:pl-3 md:text-lg"
           >
-            🎬 Mini Movies
+            <span className="text-neutral-900 dark:text-neutral-50">
+              🎬 Mini Movies
+            </span>
           </Link>
           {/* 우측 검색창: 가장자리 여백 */}
-          <div className="pr-2 md:pr-3">
+          <div className="flex items-center gap-2 pr-2 md:pr-3">
             <SearchInput />
+            <ThemeToggle />
           </div>
         </div>
       </Container>

--- a/src/components/common/SearchInput.jsx
+++ b/src/components/common/SearchInput.jsx
@@ -21,10 +21,11 @@ export default function SearchInput() {
   return (
     <form onSubmit={onSubmit} className="ml-auto w-44 md:w-64">
       <input
+        id="searchBox"
         value={q}
         onChange={(e) => setQ(e.target.value)}
         placeholder="영화 검색…"
-        className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm outline-none placeholder:text-neutral-500 focus:border-neutral-500"
+        className="w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-900 outline-none placeholder:text-neutral-500 focus:border-neutral-400 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-50 dark:placeholder:text-neutral-400 dark:focus:border-neutral-600"
         aria-label="영화 검색"
       />
     </form>

--- a/src/components/common/ThemeToggle.jsx
+++ b/src/components/common/ThemeToggle.jsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle({ className = "" }) {
+  const getInitial = () =>
+    document.documentElement.classList.contains("dark") ? "dark" : "light";
+
+  const [theme, setTheme] = useState(getInitial);
+
+  useEffect(() => {
+    const isDark = theme === "dark";
+    document.documentElement.classList.toggle("dark", isDark);
+    try {
+      localStorage.setItem("theme", isDark ? "dark" : "light");
+    } catch {
+      /* ignore */
+    }
+  }, [theme]);
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme((t) => (t === "dark" ? "light" : "dark"))}
+      aria-label="테마 전환"
+      title={theme === "dark" ? "다크 모드" : "라이트 모드"}
+      className={`rounded-md border border-neutral-300 bg-white px-2.5 py-1.5 text-sm text-neutral-900 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-50 ${className}`}
+    >
+      {theme === "dark" ? "🌙" : "☀️"}
+    </button>
+  );
+}

--- a/src/features/movie/components/MovieCard.jsx
+++ b/src/features/movie/components/MovieCard.jsx
@@ -6,7 +6,7 @@ export default function MovieCard({ movie }) {
     : "https://placehold.co/300x450?text=No+Image";
 
   return (
-    <article className="group overflow-hidden rounded-xl border border-neutral-800 bg-neutral-900 transition hover:-translate-y-0.5 hover:shadow-xl">
+    <article className="group overflow-hidden rounded-xl border border-neutral-200 bg-white text-neutral-900 transition hover:-translate-y-0.5 hover:shadow-xl dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-50">
       <Link to={`/movie/${movie.id}`} aria-label={`${movie.title} 상세보기`}>
         <img
           src={img}
@@ -17,7 +17,7 @@ export default function MovieCard({ movie }) {
       </Link>
       <div className="space-y-1 p-3">
         <h3 className="line-clamp-2 text-sm font-semibold">{movie.title}</h3>
-        <p className="text-xs text-neutral-400">
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">
           ⭐ {movie.vote_average?.toFixed?.(1) ?? "-"}
         </p>
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: "class", // ★ 중요
+  content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
+  theme: { extend: {} },
+  plugins: [],
+};


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가 (부분 적용)
- [x] 의존성/빌드 설정 업데이트
- [ ] 버그 수정
- [ ] 기능 삭제

## 반영 브랜치
`feat/17--theme-toggle` → `develop`

## 관련 이슈
#17

## 변경 사항
- Tailwind 설정에 darkMode: 'class' 활성화
- index.html에 초기 테마 스크립트(FOUC 방지) 추가
- ThemeToggle 컴포넌트 추가 (로컬스토리지 저장 로직 포함)
- AppShell / NavigationBar / MovieCard / Button에 핵심 dark: 클래스 적용
- 불필요한 하드코딩 색상 일부 정리

## 현재 상태(중요)
> 토글 UI/저장 로직까지 구현했으나 실시간 테마 전환이 완전하지 않음
(<html class="dark"> 토글이 런타임에서 일관되게 반영되지 않는 이슈 남음)