### PR TITLE
fix-theme-26-테마토글-버튼-동작-수정

### DIFF
--- a/src/components/common/NavigationBar.jsx
+++ b/src/components/common/NavigationBar.jsx
@@ -1,7 +1,7 @@
 import { useAuth } from "@/app/auth/AuthProvider.jsx";
 import Container from "@/components/common/Container.jsx";
 import SearchInput from "@/components/common/SearchInput.jsx";
-import ThemeToggle from "@/components/common/ThemeToggle.jsx";
+// import ThemeToggle from "@/components/common/ThemeToggle.jsx";
 import { Link } from "react-router-dom";
 
 export default function NavigationBar() {
@@ -33,7 +33,7 @@ export default function NavigationBar() {
               <SearchInput compact />
             </div>
 
-            <ThemeToggle />
+            {/* <ThemeToggle /> */}
 
             {user ? (
               <button

--- a/src/components/common/ThemeToggle.jsx
+++ b/src/components/common/ThemeToggle.jsx
@@ -1,30 +1,29 @@
-import { useEffect, useState } from "react";
+// import { useEffect, useState } from "react";
 
-export default function ThemeToggle() {
-  const getInitial = () =>
-    document.documentElement.classList.contains("dark") ? "dark" : "light";
-  const [theme, setTheme] = useState(getInitial);
+// export default function ThemeToggle() {
+//   const getInitial = () =>
+//     document.documentElement.classList.contains("dark") ? "dark" : "light";
+//   const [theme, setTheme] = useState(getInitial);
 
-  useEffect(() => {
-    const isDark = theme === "dark";
-    document.documentElement.classList.toggle("dark", isDark);
-    try {
-      localStorage.setItem("theme", theme);
-    } catch {
-      /* ignore */
-    }
-  }, [theme]);
+//   useEffect(() => {
+//     const isDark = theme === "dark";
+//     document.documentElement.classList.toggle("dark", isDark);
+//     try {
+//       localStorage.setItem("theme", theme);
+//     } catch {
+//       /* ignore */
+//     }
+//   }, [theme]);
 
-  return (
-    <button
-      type="button"
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      className="inline-flex h-9 items-center gap-2 rounded-xl border border-neutral-300 bg-white px-3 text-sm text-neutral-800 hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
-      aria-label="테마 전환"
-      title={theme === "dark" ? "라이트 모드" : "다크 모드"}
-    >
-      <span className="hidden sm:inline">{theme === "dark" ? "🌙" : "☀️"}</span>
-      <span className="sm:hidden">{theme === "dark" ? "🌙" : "☀️"}</span>
-    </button>
-  );
-}
+//   return null;
+//   // <button
+//   //   type="button"
+//   //   onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+//   //   className="inline-flex h-9 items-center gap-2 rounded-xl border border-neutral-300 bg-white px-3 text-sm text-neutral-800 hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+//   //   aria-label="테마 전환"
+//   //   title={theme === "dark" ? "라이트 모드" : "다크 모드"}
+//   // >
+//   //   <span className="hidden sm:inline">{theme === "dark" ? "🌙" : "☀️"}</span>
+//   //   <span className="sm:hidden">{theme === "dark" ? "🌙" : "☀️"}</span>
+//   // </button>
+// }


### PR DESCRIPTION
### 변경 내용
- ThemeToggle 컴포넌트 UI 비표시 처리(return null)
- 사용되지 않는 상태/이펙트/주석 코드 제거
- (옵션) NavigationBar에서 토글 컴포넌트 호출 주석 처리

### 이유
- 시스템 자동 테마는 정상 동작하나, 버튼은 동작 불안정하여 임시로 숨김
- 동작하지 않는 UI 노출로 인한 혼란 방지

Closes #26