### PR TITLE
refactor: Header 코드 정리(#98)

### DIFF
--- a/src/components/auth/AuthLayout.jsx
+++ b/src/components/auth/AuthLayout.jsx
@@ -1,0 +1,14 @@
+import { cn } from "@/utils/cn";
+
+export default function AuthLayout({ children, className }) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-[calc(100vh-10rem)] items-center justify-center px-4 pt-20 sm:px-6 lg:px-8",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/auth/AuthSocialButtons.jsx
+++ b/src/components/auth/AuthSocialButtons.jsx
@@ -1,0 +1,18 @@
+import { cn } from "@/utils/cn";
+
+import GoogleLoginButton from "./GoogleLoginButton";
+import KakaoLoginButton from "./KakaoLoginButton";
+
+export default function AuthSocialButtons({
+  onKakaoLogin,
+  onGoogleLogin,
+  loading,
+  className,
+}) {
+  return (
+    <div className={cn("grid grid-cols-1 gap-3", className)}>
+      <KakaoLoginButton onClick={onKakaoLogin} loading={loading} />
+      <GoogleLoginButton onClick={onGoogleLogin} loading={loading} />
+    </div>
+  );
+}

--- a/src/components/auth/SignupComplete.jsx
+++ b/src/components/auth/SignupComplete.jsx
@@ -1,0 +1,34 @@
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui";
+import { PATHS } from "@/router";
+
+import AuthCard from "./AuthCard";
+import AuthLayout from "./AuthLayout";
+import LoginIntro from "./LoginIntro";
+
+export default function SignupComplete() {
+  return (
+    <AuthLayout>
+      <AuthCard>
+        <div className="space-y-4">
+          <LoginIntro
+            title="회원가입 완료"
+            description="입력하신 주소로 인증 메일을 보냈어요."
+          />
+          <p className="text-center text-sm text-neutral-600 dark:text-neutral-400">
+            메일함에서 인증을 완료하신 후 로그인해 주세요.
+          </p>
+        </div>
+
+        <div>
+          <Link to={PATHS.LOGIN}>
+            <Button className="w-full justify-center bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-100">
+              로그인 페이지로 이동
+            </Button>
+          </Link>
+        </div>
+      </AuthCard>
+    </AuthLayout>
+  );
+}

--- a/src/components/auth/SignupForm.jsx
+++ b/src/components/auth/SignupForm.jsx
@@ -1,0 +1,92 @@
+import { Button, Input } from "@/components/ui";
+import { cn } from "@/utils/cn";
+
+export default function SignupForm({
+  email,
+  password,
+  passwordConfirm,
+  agree,
+  error,
+  loading,
+  canSubmit,
+  onEmailChange,
+  onPasswordChange,
+  onPasswordConfirmChange,
+  onAgreeChange,
+  onSubmit,
+  className,
+}) {
+  return (
+    <form onSubmit={onSubmit} className={cn("space-y-6", className)}>
+      <div className="space-y-4">
+        <Input
+          type="email"
+          name="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={onEmailChange}
+          placeholder="이메일"
+          disabled={loading}
+          className="block w-full"
+        />
+        <Input
+          type="password"
+          name="password"
+          autoComplete="new-password"
+          required
+          value={password}
+          onChange={onPasswordChange}
+          placeholder="비밀번호 (8자 이상)"
+          disabled={loading}
+          className="block w-full"
+        />
+        <Input
+          type="password"
+          name="passwordConfirm"
+          autoComplete="new-password"
+          required
+          value={passwordConfirm}
+          onChange={onPasswordConfirmChange}
+          placeholder="비밀번호 확인"
+          disabled={loading}
+          className="block w-full"
+        />
+      </div>
+
+      <div className="flex items-center">
+        <input
+          id="agree-checkbox"
+          type="checkbox"
+          checked={agree}
+          onChange={onAgreeChange}
+          className="h-4 w-4 rounded border-neutral-300 text-neutral-900 focus:ring-neutral-900 dark:border-neutral-600 dark:bg-neutral-700 dark:ring-offset-neutral-800"
+        />
+        <label
+          htmlFor="agree-checkbox"
+          className="ml-2 block text-sm text-neutral-900 dark:text-neutral-300"
+        >
+          이용약관 및 개인정보 처리에 동의합니다.
+        </label>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="text-center text-sm font-medium whitespace-pre-line text-red-500"
+        >
+          {error}
+        </div>
+      )}
+
+      <Button
+        type="submit"
+        disabled={!canSubmit}
+        className="flex w-full justify-center rounded-md bg-neutral-900 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-neutral-800 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-100"
+      >
+        {loading ? "가입 중…" : "회원가입"}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/auth/index.js
+++ b/src/components/auth/index.js
@@ -1,7 +1,11 @@
 export { default as LoginForm } from "@/components/auth/LoginForm";
 export { default as AuthCard } from "@/components/auth/AuthCard";
+export { default as AuthLayout } from "@/components/auth/AuthLayout";
 export { default as LoginIntro } from "@/components/auth/LoginIntro";
 export { default as KakaoLoginButton } from "@/components/auth/KakaoLoginButton";
 export { default as GoogleLoginButton } from "@/components/auth/GoogleLoginButton";
 export { default as AuthDivider } from "@/components/auth/AuthDivider";
 export { default as AuthActionPrompt } from "@/components/auth/AuthActionPrompt";
+export { default as SignupForm } from "@/components/auth/SignupForm";
+export { default as SignupComplete } from "@/components/auth/SignupComplete";
+export { default as AuthSocialButtons } from "@/components/auth/AuthSocialButtons";

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,54 +1,21 @@
 import { useDatabaseAuth } from "@/auth";
-import { HeaderLogo, HeaderUserLink } from "@/components/layout";
-import { AuthActionPrompt } from "@/components/auth";
-import { Container, SearchInput, ThemeToggle } from "@/components/ui";
-import { PATHS } from "@/router";
-import { Link, useLocation } from "react-router-dom";
+import { HeaderLogo } from "@/components/layout";
+import HeaderUserArea from "@/components/layout/HeaderUserArea.jsx";
+import { Container, SearchInput } from "@/components/ui";
 
 export default function Header() {
-  const location = useLocation();
   const { user, busy } = useDatabaseAuth();
   const showFloatingArea = !busy;
-  const hideAuthPrompt =
-    location.pathname === PATHS.LOGIN || location.pathname === PATHS.SIGNUP;
-
-  const userAvatar = user ? (
-    <HeaderUserLink
-      user={user}
-      className="h-16 w-16 border-4 border-white bg-neutral-100 shadow-lg md:h-20 md:w-20 dark:border-neutral-800"
-    />
-  ) : (
-    <Link
-      to={PATHS.LOGIN}
-      className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-white bg-neutral-100 shadow-lg transition-transform hover:scale-105 md:h-20 md:w-20 dark:border-neutral-800 dark:bg-neutral-800"
-    >
-      <span className="text-sm font-bold text-neutral-500 dark:text-neutral-400">
-        ON
-      </span>
-    </Link>
-  );
-
-  const signupPrompt = user || hideAuthPrompt ? null : (
-    <AuthActionPrompt
-      message="계정이 없으신가요?"
-      linkText="회원가입"
-      to={PATHS.SIGNUP}
-    />
-  );
 
   return (
     <header className="sticky top-0 z-40 border-b border-neutral-200/80 bg-white/80 px-4 backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-950/80">
       <Container>
         <div className="relative flex h-16 items-center justify-between">
-          <div className="flex flex-1 items-center justify-start"></div>
-
+          <div className="flex flex-1 items-center justify-start" />
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
             <HeaderLogo />
           </div>
-
-          <div className="flex flex-1 items-center justify-end">
-          </div>
-
+          <div className="flex flex-1 items-center justify-end" />
           <div className="absolute top-full left-1/2 mt-4 w-64 -translate-x-1/2 md:w-80">
             <SearchInput
               compact
@@ -56,20 +23,7 @@ export default function Header() {
               className="h-9 text-xs drop-shadow-xl"
             />
           </div>
-
-          {showFloatingArea ? (
-            <div className="absolute top-full right-0 -translate-y-1/2">
-              <div className="relative flex flex-col items-center space-y-3">
-                <div className="relative">
-                  {userAvatar}
-                  <div className="absolute -top-2 -right-2 z-10 flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-white shadow-md dark:border-neutral-900 dark:bg-neutral-800">
-                    <ThemeToggle className="h-full w-full hover:bg-transparent" />
-                  </div>
-                </div>
-                {signupPrompt}
-              </div>
-            </div>
-          ) : null}
+          {showFloatingArea ? <HeaderUserArea user={user} /> : null}
         </div>
       </Container>
     </header>

--- a/src/components/layout/HeaderUserArea.jsx
+++ b/src/components/layout/HeaderUserArea.jsx
@@ -1,0 +1,50 @@
+import { HeaderUserLink } from "@/components/layout";
+import { ThemeToggle } from "@/components/ui";
+import { PATHS } from "@/router";
+import { Link } from "react-router-dom";
+
+const AREA_POSITION_CLASSES = "absolute top-full right-0 -translate-y-1/2";
+
+function HeaderThemeToggle() {
+  return (
+    <div className="absolute -top-2 -right-2 z-10 flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-white shadow-md dark:border-neutral-900 dark:bg-neutral-800">
+      <ThemeToggle className="h-full w-full hover:bg-transparent" />
+    </div>
+  );
+}
+
+function HeaderAvatar({ user }) {
+  if (user) {
+    return (
+      <HeaderUserLink
+        user={user}
+        className="h-16 w-16 border-4 border-white bg-neutral-100 shadow-lg md:h-20 md:w-20 dark:border-neutral-800"
+        ariaLabel="마이페이지"
+      />
+    );
+  }
+
+  return (
+    <Link
+      to={PATHS.LOGIN}
+      className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-white bg-neutral-100 shadow-lg transition-transform hover:scale-105 md:h-20 md:w-20 dark:border-neutral-800 dark:bg-neutral-800"
+    >
+      <span className="text-sm font-bold text-neutral-500 dark:text-neutral-400">
+        ON
+      </span>
+    </Link>
+  );
+}
+
+export default function HeaderUserArea({ user }) {
+  return (
+    <div className={AREA_POSITION_CLASSES}>
+      <div className="relative flex flex-col items-center space-y-3">
+        <div className="relative">
+          <HeaderAvatar user={user} />
+          <HeaderThemeToggle />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/HeaderUserLink.jsx
+++ b/src/components/layout/HeaderUserLink.jsx
@@ -1,44 +1,30 @@
+import { useState } from "react";
 import { PATHS } from "@/router";
 import { cn } from "@/utils/cn";
+import { getUserDisplay } from "@/utils/userDisplay";
 import { Link } from "react-router-dom";
 
-function getUserDisplayInfo(user) {
-  const { user_metadata, email, identities } = user;
-  const identityData =
-    identities?.find((identity) => identity?.identity_data)?.identity_data ??
-    null;
-
-  const avatarUrl =
-    user_metadata?.avatar_url ||
-    identityData?.avatar_url ||
-    identityData?.picture ||
-    identityData?.profile_image_url;
-  if (avatarUrl) {
-    return { type: "image", value: avatarUrl };
-  }
-
-  const nickname =
-    user_metadata?.full_name ||
-    user_metadata?.name ||
-    identityData?.full_name ||
-    identityData?.name;
-  if (nickname?.length) {
-    return { type: "text", value: nickname[0].toUpperCase() };
-  }
-
-  if (email?.length) {
-    return { type: "text", value: email[0].toUpperCase() };
-  }
-
-  return null;
-}
-
 export function HeaderUserLink({ user, className }) {
-  const displayInfo = getUserDisplayInfo(user);
+  const [avatarError, setAvatarError] = useState(false);
+  const display = getUserDisplay(user);
 
-  if (!displayInfo) {
+  if (!display) {
     return null;
   }
+
+  const showAvatar = Boolean(display.avatarUrl) && !avatarError;
+  const avatarContent = showAvatar ? (
+    <img
+      src={display.avatarUrl}
+      alt="User Profile"
+      className="h-full w-full object-cover"
+      onError={() => setAvatarError(true)}
+    />
+  ) : (
+    <span className="text-base font-bold text-neutral-600 md:text-lg dark:text-neutral-300">
+      {display.initial}
+    </span>
+  );
 
   return (
     <div className="flex shrink-0 items-center gap-2">
@@ -49,17 +35,7 @@ export function HeaderUserLink({ user, className }) {
           className,
         )}
       >
-        {displayInfo.type === "image" ? (
-          <img
-            src={displayInfo.value}
-            alt="User Profile"
-            className="h-full w-full object-cover"
-          />
-        ) : (
-          <span className="text-base font-bold text-neutral-600 md:text-lg dark:text-neutral-300">
-            {displayInfo.value}
-          </span>
-        )}
+        {avatarContent}
       </Link>
     </div>
   );

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -1,4 +1,5 @@
 export { default as Header } from "@/components/layout/Header.jsx";
+export { default as HeaderUserArea } from "@/components/layout/HeaderUserArea.jsx";
 export * from "@/components/layout/HeaderAuthLinks.jsx";
 export * from "@/components/layout/HeaderLogo.jsx";
 export * from "@/components/layout/HeaderUserLink.jsx";

--- a/src/hooks/useSignupForm.js
+++ b/src/hooks/useSignupForm.js
@@ -1,0 +1,110 @@
+import { useDatabaseAuth } from "@/auth";
+import { useCallback, useState } from "react";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+const ERROR_MESSAGES = {
+  agree: "약관에 동의해 주세요.",
+  passwordMismatch: "비밀번호가 일치하지 않습니다.",
+  passwordLength: `비밀번호는 ${MIN_PASSWORD_LENGTH}자 이상이어야 합니다.`,
+  signup:
+    "회원가입에 실패했습니다." +
+    "\n" +
+    "이메일을 바꾸거나 잠시 후 다시 시도해 주세요.",
+};
+
+export default function useSignupForm() {
+  const { signUp } = useDatabaseAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+  const [agree, setAgree] = useState(false);
+  const [error, setError] = useState("");
+  const [isComplete, setIsComplete] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleEmailChange = useCallback((event) => {
+    setEmail(event.target.value);
+  }, []);
+
+  const handlePasswordChange = useCallback((event) => {
+    setPassword(event.target.value);
+  }, []);
+
+  const handlePasswordConfirmChange = useCallback((event) => {
+    setPasswordConfirm(event.target.value);
+  }, []);
+
+  const handleAgreeChange = useCallback((event) => {
+    setAgree(event.target.checked);
+  }, []);
+
+  const validate = useCallback(() => {
+    if (!agree) return ERROR_MESSAGES.agree;
+    if (password !== passwordConfirm) return ERROR_MESSAGES.passwordMismatch;
+    if (password.length < MIN_PASSWORD_LENGTH) return ERROR_MESSAGES.passwordLength;
+    return "";
+  }, [agree, password, passwordConfirm]);
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event?.preventDefault?.();
+      setError("");
+
+      const trimmedEmail = email.trim();
+      const validationError = validate();
+      if (validationError) {
+        setError(validationError);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const { error: signupError } = await signUp(trimmedEmail, password);
+        if (signupError) throw signupError;
+        setIsComplete(true);
+      } catch {
+        setError(ERROR_MESSAGES.signup);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [email, password, signUp, validate],
+  );
+
+  const resetForm = useCallback(() => {
+    setEmail("");
+    setPassword("");
+    setPasswordConfirm("");
+    setAgree(false);
+    setError("");
+    setIsComplete(false);
+    setLoading(false);
+  }, []);
+
+  const trimmedEmail = email.trim();
+  const canSubmit =
+    !loading &&
+    agree &&
+    trimmedEmail.length > 0 &&
+    password.length >= MIN_PASSWORD_LENGTH &&
+    passwordConfirm.length > 0 &&
+    password === passwordConfirm;
+
+  return {
+    email,
+    password,
+    passwordConfirm,
+    agree,
+    error,
+    isComplete,
+    loading,
+    canSubmit,
+    handleEmailChange,
+    handlePasswordChange,
+    handlePasswordConfirmChange,
+    handleAgreeChange,
+    handleSubmit,
+    resetForm,
+  };
+}

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -2,8 +2,8 @@ import {
   AuthActionPrompt,
   AuthCard,
   AuthDivider,
-  GoogleLoginButton,
-  KakaoLoginButton,
+  AuthLayout,
+  AuthSocialButtons,
   LoginForm,
   LoginIntro,
 } from "@/components/auth";
@@ -25,22 +25,16 @@ export default function LoginPage() {
   } = useLoginForm();
 
   return (
-    <div className="flex min-h-[calc(100vh-10rem)] items-center justify-center px-4 pt-20 sm:px-6 lg:px-8">
+    <AuthLayout>
       <AuthCard>
-        <div className="text-center">
-          <LoginIntro />
-        </div>
-        <div className="mt-8 space-y-6">
-          <div className="grid grid-cols-1 gap-3">
-            <KakaoLoginButton
-              onClick={handleKakaoLogin}
-              loading={socialLoading}
-            />
-            <GoogleLoginButton
-              onClick={handleGoogleLogin}
-              loading={socialLoading}
-            />
-          </div>
+        <LoginIntro />
+
+        <div className="space-y-6">
+          <AuthSocialButtons
+            onKakaoLogin={handleKakaoLogin}
+            onGoogleLogin={handleGoogleLogin}
+            loading={socialLoading}
+          />
           <AuthDivider />
           <LoginForm
             email={email}
@@ -58,6 +52,6 @@ export default function LoginPage() {
           />
         </div>
       </AuthCard>
-    </div>
+    </AuthLayout>
   );
 }

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -1,161 +1,64 @@
-import { useState } from "react";
-import { Link } from "react-router-dom";
-
-import { useDatabaseAuth } from "@/auth";
-import { AuthActionPrompt } from "@/components/auth";
-import { Button, Input } from "@/components/ui";
+import {
+  AuthActionPrompt,
+  AuthCard,
+  AuthLayout,
+  LoginIntro,
+  SignupComplete,
+  SignupForm,
+} from "@/components/auth";
+import useSignupForm from "@/hooks/useSignupForm";
 import { PATHS } from "@/router";
 
 export default function SignupPage() {
-  const { signUp } = useDatabaseAuth();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [passwordConfirm, setPasswordConfirm] = useState("");
-  const [error, setError] = useState("");
-  const [isComplete, setIsComplete] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [agree, setAgree] = useState(false);
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    setError("");
-
-    if (!agree) {
-      setError("약관에 동의해 주세요.");
-      return;
-    }
-    if (password !== passwordConfirm) {
-      setError("비밀번호가 일치하지 않습니다.");
-      return;
-    }
-    if (password.length < 8) {
-      setError("비밀번호는 8자 이상이어야 합니다.");
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const { error } = await signUp(email, password);
-      if (error) throw error;
-      setIsComplete(true);
-    } catch {
-      setError(
-        "회원가입에 실패했습니다." +
-          "\n" +
-          "이메일을 바꾸거나 잠시 후 다시 시도해 주세요.",
-      );
-    } finally {
-      setLoading(false);
-    }
-  };
+  const {
+    email,
+    password,
+    passwordConfirm,
+    agree,
+    error,
+    isComplete,
+    loading,
+    canSubmit,
+    handleEmailChange,
+    handlePasswordChange,
+    handlePasswordConfirmChange,
+    handleAgreeChange,
+    handleSubmit,
+  } = useSignupForm();
 
   if (isComplete) {
-    return (
-      <div className="flex min-h-[calc(100vh-10rem)] items-center justify-center px-4 pt-20 sm:px-6 lg:px-8">
-        <div className="w-full max-w-md space-y-8 rounded-xl bg-white p-8 shadow-lg dark:bg-neutral-800">
-          <div className="text-center">
-            <h2 className="text-3xl font-bold tracking-tight text-neutral-900 dark:text-white">
-              회원가입 완료
-            </h2>
-            <div className="mt-4 text-sm text-neutral-600 dark:text-neutral-400">
-              <p>
-                입력하신 주소로 <strong>인증 메일</strong>을 보냈어요.
-              </p>
-              <p className="mt-1">
-                메일함에서 인증을 완료하신 후 로그인해 주세요.
-              </p>
-            </div>
-          </div>
-
-          <div className="mt-8">
-            <Link to={PATHS.LOGIN}>
-              <Button className="w-full justify-center bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-100">
-                로그인 페이지로 이동
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </div>
-    );
+    return <SignupComplete />;
   }
 
   return (
-    <div className="flex min-h-[calc(100vh-10rem)] items-center justify-center px-4 pt-20 sm:px-6 lg:px-8">
-      <div className="w-full max-w-md space-y-8 rounded-xl bg-white p-8 shadow-lg dark:bg-neutral-800">
-        <div className="text-center">
-          <h2 className="text-3xl font-bold tracking-tight text-neutral-900 dark:text-white">
-            회원가입
-          </h2>
-          <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
-            새로운 계정을 만들어 서비스를 이용해보세요.
-          </p>
-        </div>
+    <AuthLayout>
+      <AuthCard>
+        <LoginIntro
+          title="회원가입"
+          description="새로운 계정을 만들어 서비스를 이용해보세요."
+        />
 
-        <form onSubmit={handleSubmit} className="mt-8 space-y-6">
-          <div className="space-y-4">
-            <Input
-              type="email"
-              required
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="이메일"
-              className="block w-full"
-            />
-            <Input
-              type="password"
-              required
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="비밀번호 (8자 이상)"
-              className="block w-full"
-            />
-            <Input
-              type="password"
-              required
-              value={passwordConfirm}
-              onChange={(e) => setPasswordConfirm(e.target.value)}
-              placeholder="비밀번호 확인"
-              className="block w-full"
-            />
-          </div>
-
-          <div className="flex items-center">
-            <input
-              id="agree-checkbox"
-              type="checkbox"
-              checked={agree}
-              onChange={(e) => setAgree(e.target.checked)}
-              className="h-4 w-4 rounded border-neutral-300 text-neutral-900 focus:ring-neutral-900 dark:border-neutral-600 dark:bg-neutral-700 dark:ring-offset-neutral-800"
-            />
-            <label
-              htmlFor="agree-checkbox"
-              className="ml-2 block text-sm text-neutral-900 dark:text-neutral-300"
-            >
-              이용약관 및 개인정보 처리에 동의합니다.
-            </label>
-          </div>
-
-          {error && (
-            <div className="text-center text-sm font-medium whitespace-pre-line text-red-500">
-              {error}
-            </div>
-          )}
-
-          <Button
-            type="submit"
-            disabled={loading}
-            className="flex w-full justify-center rounded-md bg-neutral-900 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-neutral-800 dark:bg-white dark:text-neutral-900 dark:hover:bg-neutral-100"
-          >
-            {loading ? "가입 중…" : "회원가입"}
-          </Button>
-        </form>
+        <SignupForm
+          email={email}
+          password={password}
+          passwordConfirm={passwordConfirm}
+          agree={agree}
+          error={error}
+          loading={loading}
+          canSubmit={canSubmit}
+          onEmailChange={handleEmailChange}
+          onPasswordChange={handlePasswordChange}
+          onPasswordConfirmChange={handlePasswordConfirmChange}
+          onAgreeChange={handleAgreeChange}
+          onSubmit={handleSubmit}
+        />
 
         <AuthActionPrompt
           message="이미 계정이 있으신가요?"
           linkText="로그인"
           to={PATHS.LOGIN}
         />
-      </div>
-    </div>
+      </AuthCard>
+    </AuthLayout>
   );
 }

--- a/src/utils/userDisplay.js
+++ b/src/utils/userDisplay.js
@@ -1,0 +1,44 @@
+function pickFirstString(...values) {
+  for (const value of values) {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length) {
+        return trimmed;
+      }
+    }
+  }
+  return null;
+}
+
+export function getUserDisplay(user) {
+  if (!user) {
+    return null;
+  }
+
+  const { user_metadata, email, identities } = user;
+  const identityData =
+    identities?.find((identity) => identity?.identity_data)?.identity_data ??
+    null;
+
+  const avatarUrl = pickFirstString(
+    user_metadata?.avatar_url,
+    identityData?.avatar_url,
+    identityData?.picture,
+    identityData?.profile_image_url,
+  );
+
+  const initial =
+    pickFirstString(
+      user_metadata?.full_name,
+      user_metadata?.name,
+      identityData?.full_name,
+      identityData?.name,
+      email,
+    )?.[0]?.toUpperCase() ?? null;
+
+  if (!avatarUrl && !initial) {
+    return null;
+  }
+
+  return { avatarUrl, initial };
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#98 
## 🪄 작업내용
- 헤더 사용자 표시, 테마 토글을 분리해 레이아웃 정리
- 로그인/회원가입 페이지를 공용 레이아웃과 컴포넌트로 재구성
- 회원가입 안내와 검증 로직을 훅/컴포넌트로 분리해 UX 개선