### PR TITLE
refactor: 위시리스트 담기(#102)

### DIFF
--- a/src/hooks/useWishlist.js
+++ b/src/hooks/useWishlist.js
@@ -25,11 +25,16 @@ export default function useWishlist() {
 
   const queryKey = ["wishlist", userId];
 
-  const { data: items = [] } = useQuery({
+  const {
+    data: items = [],
+    isLoading,
+    isFetching,
+    isPlaceholderData,
+  } = useQuery({
     queryKey,
     queryFn: () => wishlistService.getItems(userId),
     enabled: !!userId,
-    initialData: [],
+    placeholderData: [],
   });
 
   const { mutate: addMutate } = useMutation({
@@ -140,5 +145,8 @@ export default function useWishlist() {
     contains,
     isAuthenticated,
     isAuthLoading,
+    isLoading,
+    isFetching,
+    isPlaceholderData,
   };
 }

--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -8,6 +8,7 @@ import DetailPageError from "@/components/movies/detail/DetailPageError";
 import DetailPageSkeleton from "@/components/movies/detail/DetailPageSkeleton";
 import { Container, Section, SectionHeader } from "@/components/ui";
 import { useMovieDetail, useSimilarMovies } from "@/hooks/movies";
+import { useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 const SIMILAR_MOVIES_LIMIT = 10;
@@ -17,6 +18,12 @@ export default function DetailPage() {
   const { id } = useParams();
   const { data: movieDetail, isLoading, error } = useMovieDetail(Number(id));
   const { data: similarMovies } = useSimilarMovies(Number(id));
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    }
+  }, [id]);
 
   if (isLoading) {
     return <DetailPageSkeleton />;

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,10 +1,10 @@
 import { useDatabaseAuth } from "@/auth";
-import { MovieGrid } from "@/components/movies";
+import { MovieGrid, MovieGridSkeleton } from "@/components/movies";
 import { Container, EmptyState, Section } from "@/components/ui";
 import useWishlist from "@/hooks/useWishlist";
 import { PATHS } from "@/router";
 import { useMemo } from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 const LABELS = {
   email: "이메일",
@@ -13,7 +13,12 @@ const LABELS = {
 
 export default function MyPage() {
   const { user, logout } = useDatabaseAuth();
-  const { items: wishlist } = useWishlist();
+  const {
+    items: wishlist,
+    isLoading: wishlistLoading,
+    isPlaceholderData,
+  } = useWishlist();
+  const navigate = useNavigate();
 
   const userInfo = user;
 
@@ -83,17 +88,22 @@ export default function MyPage() {
             )}
           </div>
 
-          <Link
-            to={PATHS.HOME}
-            onClick={() => logout()}
+          <button
+            type="button"
+            onClick={async () => {
+              await logout();
+              navigate(PATHS.HOME, { replace: true });
+            }}
             className="mt-4 inline-flex items-center justify-center rounded-full border border-neutral-200 bg-white px-6 py-2 text-sm font-medium text-neutral-600 transition-colors hover:bg-neutral-50 hover:text-neutral-900 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:bg-neutral-700 dark:hover:text-neutral-200"
           >
             로그아웃
-          </Link>
+          </button>
         </div>
       </Section>
 
-      {wishlist.length === 0 ? (
+      {wishlistLoading || isPlaceholderData ? (
+        <MovieGridSkeleton count={6} />
+      ) : wishlist.length === 0 ? (
         <EmptyState message="아직 위시리스트에 담은 영화가 없습니다." />
       ) : (
         <MovieGrid movies={wishlist} />

--- a/supabase/wishlist.sql
+++ b/supabase/wishlist.sql
@@ -1,0 +1,45 @@
+-- Create wishlist table and policies for Supabase
+create table if not exists public.wishlist (
+  id bigint generated always as identity primary key,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  movie_id bigint not null,
+  movie jsonb not null,
+  created_at timestamptz not null default now(),
+  constraint wishlist_user_movie_unique unique (user_id, movie_id)
+);
+
+-- Enable row level security
+alter table public.wishlist enable row level security;
+
+-- Create policies only if they do not exist (prevents duplicate errors)
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where policyname = 'Users can view own wishlist'
+  ) then
+    create policy "Users can view own wishlist" on public.wishlist
+      for select using (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies where policyname = 'Users can insert into own wishlist'
+  ) then
+    create policy "Users can insert into own wishlist" on public.wishlist
+      for insert with check (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies where policyname = 'Users can delete from own wishlist'
+  ) then
+    create policy "Users can delete from own wishlist" on public.wishlist
+      for delete using (auth.uid() = user_id);
+  end if;
+end$$;
+
+-- Grant privileges to authenticated users (required alongside RLS policies)
+grant usage on schema public to authenticated;
+grant select, insert, delete on public.wishlist to authenticated;
+
+-- If your anon key is used for API calls, also grant permissions to anon
+grant usage on schema public to anon;
+grant select, insert, delete on public.wishlist to anon;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#102 
## 🪄 작업내용
- [x] supabase 스키마/정책 정리
  - supabase에 whishlist.sql로 테이블 생성,
  - RLS활성화,
  - Select/Insert/Delete 정책 추가,
  - authenticated/anon롤에 select/insert/delete 권한 부여
- [x] 위시리스트 새로고침 시 바로 fetch하도록 수정
  - useWishlist의 initialData를 제거, placeholderData로 교체
- [x] 위시리스트 로딩 UX
  - MyPage에 로딩중일 때, MovieGridSkeleton을 보여주고,
  - 로딩 후에 빈 상태/목록을 렌더 하도록 변경.